### PR TITLE
replace deprecated ICACHE_RAM_ATTR with IRAM_ATTR

### DIFF
--- a/src/DHT.hpp
+++ b/src/DHT.hpp
@@ -57,11 +57,11 @@ class DHT {
   Ticker _timer;
   volatile int8_t _counter;
   volatile uint32_t _previousMicros;
-  static void ICACHE_RAM_ATTR _handleRead(DHT* a);
-  static void ICACHE_RAM_ATTR _handleData(void* a);
-  void ICACHE_RAM_ATTR _stop(uint8_t status);
-  static void ICACHE_RAM_ATTR _timeout(DHT* a);
-  void ICACHE_RAM_ATTR _tryCallback();
+  static void IRAM_ATTR _handleRead(DHT* a);
+  static void IRAM_ATTR _handleData(void* a);
+  void IRAM_ATTR _stop(uint8_t status);
+  static void IRAM_ATTR _timeout(DHT* a);
+  void IRAM_ATTR _tryCallback();
   virtual float _getHumidity() = 0;
   virtual float _getTemperature() = 0;
 };


### PR DESCRIPTION
When building with PIO, I get mutliple warnings about deprecated `ICACHE_RAM_ATTR`:

> warning: 'void DHT::_stop(uint8_t)' is deprecated: Use IRAM_ATTR in place of ICACHE_RAM_ATTR to move functions into IRAM [-Wdeprecated-declarations]

This change simply updates the hpp files to use the newer `IRAM_ATTR`.